### PR TITLE
Explicitly point to types in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Debounce async functions by resolve status",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
     "test": "jest"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "declaration": true,
     "outDir": "dist",
     "strict": true,
-    "esModuleInterop": true
+    "esModuleInterop": false
   },
   "include": ["./src"],
   "exclude": [


### PR DESCRIPTION
Should fix this error:

`Type ‘typeof import(“/node_modules/@nexapp/debounce-await/dist/index”)’ has no call signatures.`